### PR TITLE
Fixing ignore option causing failure

### DIFF
--- a/index.js
+++ b/index.js
@@ -2,12 +2,11 @@ const minimatch = require('minimatch').Minimatch
 const convert = require('convert-source-map')
 const through = require('through2')
 const path = require('path')
-const xtend = require('xtend')
 
 module.exports = uglifyify
 
 function uglifyify (file, opts) {
-  opts = xtend(opts || {})
+  opts = Object.assign({}, opts || {});
 
   let debug = opts._flags && opts._flags.debug
   // lazy require `terser` so uglifyify can be loaded on very old node.js versions
@@ -16,6 +15,7 @@ function uglifyify (file, opts) {
   if (ignore(file, opts.ignore)) {
     return through()
   }
+  delete opts.ignore;
 
   let buffer = ''
   const exts = []
@@ -45,7 +45,7 @@ function uglifyify (file, opts) {
   }, capture(function ready (callback) {
     const stream = this
     debug = opts.sourceMap !== false && debug
-    opts = xtend({
+    opts = Object.assign({
       compress: true,
       mangle: true,
       sourceMap: {
@@ -57,7 +57,7 @@ function uglifyify (file, opts) {
     mapArgv(opts)
 
     if (typeof opts.compress === 'object') {
-      opts.compress = xtend(opts.compress || {})
+      opts.compress = Object.assign({}, opts.compress || {})
       delete opts.compress._
     }
 

--- a/package.json
+++ b/package.json
@@ -7,8 +7,7 @@
     "convert-source-map": "^1.9.0",
     "minimatch": "^3.0.2",
     "terser": "^5.15.1",
-    "through2": "^4.0.2",
-    "xtend": "^4.0.1"
+    "through2": "^4.0.2"
   },
   "devDependencies": {
     "bl": "^5.0.0",


### PR DESCRIPTION
Passing in ignore fails due to it being a valid option for uglifyify but not for terser preventing it from being used.

This would fail, with a list of patterns to ignore or even an empty list:
```js
b.transform('@browserify/uglifyify', { ignore: [] });
```

The change deletes the ignore option after checking it.

Also removed the use of xtend since when I looked at it to see if the deleting of a property would break something else the documentation for it made it very clear that it shouldn't be used. 